### PR TITLE
feat: Added resource attrib in InitContainer

### DIFF
--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -63,6 +63,7 @@ type InitContainer struct {
 	Args          []string                       `json:"args,omitempty"`
 	WorkingDir    string                         `json:"workingDir,omitempty"`
 	VolumeMounts  []corev1.VolumeMount           `json:"volumeMounts,omitempty"`
+	Resources     corev1.ResourceRequirements    `json:"resources,omitempty"`
 	RestartPolicy *corev1.ContainerRestartPolicy `json:"restartPolicy,omitempty"`
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -60,6 +60,7 @@ func (in *InitContainer) DeepCopyInto(out *InitContainer) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	if in.RestartPolicy != nil {
 		in, out := &in.RestartPolicy, &out.RestartPolicy
 		*out = new(v1.ContainerRestartPolicy)

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -802,6 +802,39 @@ spec:
                           type: string
                         name:
                           type: string
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
                         restartPolicy:
                           type: string
                         volumeMounts:
@@ -2802,6 +2835,39 @@ spec:
                           type: string
                         name:
                           type: string
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
                         restartPolicy:
                           type: string
                         volumeMounts:
@@ -4823,6 +4889,39 @@ spec:
                           type: string
                         name:
                           type: string
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
                         restartPolicy:
                           type: string
                         volumeMounts:

--- a/pkg/resources/jobs/helpers.go
+++ b/pkg/resources/jobs/helpers.go
@@ -141,6 +141,7 @@ func getInitContainers(pod *v1alpha1.Pod, script *types.Script) []corev1.Contain
 			ImagePullPolicy: pod.ImagePullPolicy,
 			SecurityContext: &pod.ContainerSecurityContext,
 			RestartPolicy:   k6InitContainer.RestartPolicy,
+			Resources:       k6InitContainer.Resources,
 		}
 		initContainers = append(initContainers, initContainer)
 	}


### PR DESCRIPTION
This pull request adds support for specifying resource requirements (such as CPU and memory limits/requests) for `InitContainer` definitions in the `TestRun` custom resource. This enhancement ensures that resource constraints can be set and propagated through the API, CRD schema, and runtime container creation.

**Resource requirements support for InitContainers:**

* Added a new `Resources` field of type `corev1.ResourceRequirements` to the `InitContainer` struct in `testrun_types.go`, allowing specification of resource limits and requests.
* Updated the generated `DeepCopyInto` method for `InitContainer` to properly deep copy the new `Resources` field.
* Updated the CRD schema (`k6.io_testruns.yaml`) in three places to include the `resources` field for `initContainers`, supporting `limits`, `requests`, and `claims` as per Kubernetes conventions. [[1]](diffhunk://#diff-3d879b1c08a89afab16627461964a3546720b98d4c590612701085e24924a203R805-R837) [[2]](diffhunk://#diff-3d879b1c08a89afab16627461964a3546720b98d4c590612701085e24924a203R2838-R2870) [[3]](diffhunk://#diff-3d879b1c08a89afab16627461964a3546720b98d4c590612701085e24924a203R4892-R4924)
* Modified the `getInitContainers` helper in `helpers.go` to set the `Resources` field when creating init containers, ensuring the resource requirements are applied at runtime.